### PR TITLE
Add suggestions to decoded error

### DIFF
--- a/src/service/errorDecoder/providers/entrypoint/decoders/AA21Decoder.ts
+++ b/src/service/errorDecoder/providers/entrypoint/decoders/AA21Decoder.ts
@@ -3,23 +3,33 @@ import { networkConfig } from "../../../../../config/network";
 import { EntryPointFactory } from "../../../../../repository/entryPoint/factory";
 import { DecodedError, ErrorSource } from "../../../../../types";
 import { ErrorDecoderParams, IErrorDecoder } from "../../../interface/IErrorDecoder";
+import { trim } from "../../../../../utils";
 
 export class AA21Decoder implements IErrorDecoder {
+
     async decodeError(param: ErrorDecoderParams): Promise<DecodedError> {
         // TODO: Extract more information that is related to this error eg., the amount of native balance the smart account has
         // and how much is needed to pay for the gas.
         let epService = EntryPointFactory.getEntryPointService(param.entryPointAddress);
         let requiredFunds;
+        let symbol, suggestedActions: string[] = [];
         if(epService) {
             let maxTransactionFee = await epService.getRequiredPreFund(param.userOp);
-            let symbol = networkConfig[param.networkId].nativeSymbol;
+            symbol = networkConfig[param.networkId].nativeSymbol;
             requiredFunds = `${formatEther(maxTransactionFee)} ${symbol}`;
         }
+        if(requiredFunds && symbol) {
+            suggestedActions = [
+                `Please add at least ${trim(requiredFunds, 5)} ${symbol} to the Smart Account.`,
+                `You can use a paymaster to either sponsor the gas fee or use ERC20 tokens to pay for the gas.`
+            ];
+        }   
 
         return {
             message: `Smart Account is supposed to pay for this userOp but it does not have enough native balance to pay for the gas.
             Max ${requiredFunds} is required to pay for the gas.}`,
-            errorSource: ErrorSource.SMART_ACCOUNT
+            errorSource: ErrorSource.SMART_ACCOUNT,
+            suggestions: suggestedActions
         }
     }
     

--- a/src/service/errorDecoder/providers/entrypoint/decoders/AA21Decoder.ts
+++ b/src/service/errorDecoder/providers/entrypoint/decoders/AA21Decoder.ts
@@ -27,7 +27,7 @@ export class AA21Decoder implements IErrorDecoder {
 
         return {
             message: `Smart Account is supposed to pay for this userOp but it does not have enough native balance to pay for the gas.
-            Max ${requiredFunds} is required to pay for the gas.}`,
+            Max ${requiredFunds} is required to pay for the gas.`,
             errorSource: ErrorSource.SMART_ACCOUNT,
             suggestions: suggestedActions
         }

--- a/src/types/userOp.ts
+++ b/src/types/userOp.ts
@@ -31,6 +31,7 @@ export interface Error {
 export interface DecodedError {
     message: string;
     errorSource: ErrorSource;
+    suggestions: string[];
 }
 
 export enum ErrorSource {

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,2 +1,3 @@
 export * from './userOpUtils';
 export * from './date';
+export * from './math';

--- a/src/utils/math.ts
+++ b/src/utils/math.ts
@@ -1,0 +1,5 @@
+export function trim(numberString: string, decimalPlaces: number): string {
+    const regex = new RegExp(`^-?\\d+(?:\\.\\d{0,${decimalPlaces}})?`);
+    const match = numberString.match(regex);
+    return match ? match[0] : numberString;
+}


### PR DESCRIPTION
### Fixes [Issue 32](https://github.com/bcnmy/userop-debugger-backend/issues/32)

Added suggestions field to `DecodedError` type and implemented respective decoder classes to reflect the changes.

The suggestions field is a string array, and values can be in markdown format as well. The frontend should parse them as markdown formatted strings.
