### PR TITLE
Handle invalid paymaster signature for biconomy paymaster

### DIFF
--- a/src/types/paymaster.ts
+++ b/src/types/paymaster.ts
@@ -1,3 +1,4 @@
+import { DecodedError } from ".";
 import { IPaymaster } from "../repository/paymaster/interface";
 import { PaymasterDecoderConfig } from "../service/paymasterDecoder";
 import { IPaymasterDecoder } from "../service/paymasterDecoder/interface/IPaymasterDecoder";
@@ -14,6 +15,7 @@ export interface PaymasterInfo {
     type: PaymasterType;
     gasPaymentToken?: TokenInfo;
     exchangeRate?: string;
+    error?: DecodedError;
     moreInfo?: {};
 }
 


### PR DESCRIPTION
In case the paymaster verification fails on chain and EP returns AA34 error, it means that signature was not verified by the Paymaster properly. In that case we need to check if the singer recovered from the paymaster signature and hash is the expected signer on paymaster.

In this case, we need to return decoded error in paymasterInfo as well to have better visibility to the developers.

Added `DecodedError` type field in `PaymasterInfo` as well to return this decoded error from paymaster.